### PR TITLE
Adding properties for uploading file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Any files smaller than the specified number will be downloaded in a single threa
 
 * `explode_archive`: *Default: false* If true, the command will extract an archive containing multiple artifacts after it is deployed to Artifactory, while maintaining the archive's file structure.
 
+* `props`: *Optional.* List of properties in the form of "key1=value1;key2=value2,...". Those properties will be added to uploaded file. If both `props` and `props_from_file` are set values will be merged.
+
+* `props_from_file`: *Optional.* Path to file which will contain list of properties. List should be in the form of "key1=value1;key2=value2,...". Those properties will be added to uploaded file. If both `props` and `props_from_file` are set values will be merged.
+
 ## Example
 
 ``` yaml

--- a/model/model.go
+++ b/model/model.go
@@ -27,4 +27,6 @@ type OutParams struct {
 	Source         string `json:"source"`
 	Threads        int    `json:"threads"`
 	ExplodeArchive bool   `json:"explode_archive"`
+	Props          string `json:"props"`
+	PropsFromFile  string `json:"props_from_file"`
 }


### PR DESCRIPTION
In some cases we would like to add properties when uploading file to Artifactory.
Before this PR it's possible to set 'props' field in source configuration, but according to README file it should be used to filter artifacts when downloading.

So: this PR introduce possibility to explicitly set list of properties in 'out' params.
You can set properties directly in pipeline (in field props) or during build in file and set path to that file in props_from_file.

@ArthurHlt Let me know if you have any comments/questions.