### PR TITLE
Add retrieving Artifactory properties of downloaded file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Any files smaller than the specified number will be downloaded in a single threa
 
 * `split_count`: *Default: 3* The number of segments into which each file should be split for download (provided the artifact is over --min-split in size). To download each file in a single thread, set to 0.
 
+* `props_filename`: *Optional.* Path to file where Artifactory properties of downloaded file will be stored. File will contain whole REST API response and properties values can be extracted with other tools like jq. If parameter is empty - no request to Artifactory will be made.
+
 ### `out`: Upload a file to artifactory.
 
 #### Parameters

--- a/model/model.go
+++ b/model/model.go
@@ -16,11 +16,12 @@ type Source struct {
 	CACert    string `json:"ca_cert"`
 }
 type InParams struct {
-	Filename   string `json:"filename"`
-	Notflat    bool   `json:"not_flat"`
-	Threads    int    `json:"threads"`
-	MinSplit   int    `json:"min_split"`
-	SplitCount int    `json:"split_count"`
+	Filename      string `json:"filename"`
+	Notflat       bool   `json:"not_flat"`
+	Threads       int    `json:"threads"`
+	MinSplit      int    `json:"min_split"`
+	SplitCount    int    `json:"split_count"`
+	PropsFilename string `json:"props_filename"`
 }
 type OutParams struct {
 	Target         string `json:"target"`


### PR DESCRIPTION
Related to #1.
If we store properties like in #1 we would like to get them in another pipeline.
Unfortunetly jfrog cli doesn't support getting properties so REST API is used directly.

@ArthurHlt Let me know if you have any questions/comments.

Both PRs are based on master branch so in case of merging one the other may need rebase. Of course I'll do it if necessary.